### PR TITLE
Fix validation in UmbracoIFormFileExtensionsAttribute when file extension is in Upper Case

### DIFF
--- a/src/UmbracoIFormFileExtensionsAttribute.cs
+++ b/src/UmbracoIFormFileExtensionsAttribute.cs
@@ -53,7 +53,7 @@ namespace Our.Umbraco.ValidationAttributes
             
             if (file != null)
             {
-                isValid = ValidFileTypes.Any(x => file.FileName.EndsWith(x));
+                isValid = ValidFileTypes.Any(x => file.FileName.ToLower().EndsWith(x));
             }
 
             return isValid;


### PR DESCRIPTION
Hi @ZioTino, 

I found out that UmbracoIFormFileExtensionsAttribute doesn't work correctly if the uploading file extension is in uppercase. So I added toLower in the validation.